### PR TITLE
Fix race condition dead awaits

### DIFF
--- a/src/runtime.iced
+++ b/src/runtime.iced
@@ -80,7 +80,7 @@ exports.Deferrals = class Deferrals
   #----------
 
   constructor: (@iterator, @trace) ->
-    @count = 0
+    @count = 1
     @ret = null
     @yielded = false
 
@@ -104,6 +104,8 @@ exports.Deferrals = class Deferrals
   #----------
 
   await_exit : () ->
+    @_fulfill()
+
     if @count == 0
       @iterator = null
       return false


### PR DESCRIPTION
Start Deferrals with counter = 1, but immediately call _fullfill in
await_exit. This way, Deferrals will never be considered 'done' in the
middle of creating defer_returns.

Fixes https://github.com/maxtaco/coffee-script/issues/175
